### PR TITLE
let it use its own installer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,3 +46,5 @@ RUN ${INSTALLDIR}/entrypoint.sh --test \
 STOPSIGNAL SIGINT
 # In order to pass variables along to Exec Form Bash, we need to copy them explicitly
 ENTRYPOINT ["/bin/bash", "-c", "${INSTALLDIR}/entrypoint.sh \"$0\" \"$@\""]
+
+CMD ["--listen", "--no-download", "--docs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,6 @@ RUN ${INSTALLDIR}/entrypoint.sh --test \
     --no-download \
     --skip-torch
 
-
 STOPSIGNAL SIGINT
 # In order to pass variables along to Exec Form Bash, we need to copy them explicitly
 ENTRYPOINT ["/bin/bash", "-c", "${INSTALLDIR}/entrypoint.sh \"$0\" \"$@\""]

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,9 +40,7 @@ WORKDIR $INSTALLDIR
 USER root
 
 RUN ${INSTALLDIR}/entrypoint.sh --test \
-    --api-only \
     --no-download \
-    --skip-extensions \
     --skip-torch
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
               capabilities: [gpu]
     environment:
       DATA_DIR: "./data"
-    image: ${REGISTRY:-saladtechnologies}/sdnext:extensions
+    image: ${REGISTRY:-saladtechnologies}/sdnext:latest
     ports:
       - "7860:7860"
     stdin_open: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,7 @@ services:
     command: |
       --listen
       --docs
-      --api-only
       --no-download
-      --skip-extensions
     # --no-half
     # --skip-requirements
     
@@ -29,7 +27,7 @@ services:
               capabilities: [gpu]
     environment:
       DATA_DIR: "./data"
-    image: ${REGISTRY:-saladtechnologies}/sdnext:latest
+    image: ${REGISTRY:-saladtechnologies}/sdnext:extensions
     ports:
       - "7860:7860"
     stdin_open: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,11 +12,11 @@ services:
       --docs
       --api-only
       --no-download
-      --no-half
-      --skip-requirements
-      --skip-extensions
-      --skip-git
-      --skip-torch
+    # --no-half
+    # --skip-requirements
+    # --skip-extensions
+    # --skip-git
+    # --skip-torch
     # --xformers
     # --no-half-vae
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,10 @@ services:
       --docs
       --api-only
       --no-download
+      --skip-extensions
     # --no-half
     # --skip-requirements
-    # --skip-extensions
+    
     # --skip-git
     # --skip-torch
     # --xformers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,13 +11,6 @@ services:
       --listen
       --docs
       --no-download
-    # --no-half
-    # --skip-requirements
-    
-    # --skip-git
-    # --skip-torch
-    # --xformers
-    # --no-half-vae
     deploy:
       resources:
         reservations:
@@ -25,17 +18,6 @@ services:
             - driver: nvidia
               count: all
               capabilities: [gpu]
-    environment:
-      DATA_DIR: "./data"
-    image: ${REGISTRY:-saladtechnologies}/sdnext:extensions
+    image: ${REGISTRY:-saladtechnologies}/sdnext:latest
     ports:
       - "7860:7860"
-    stdin_open: true
-    tmpfs:
-      - /tmp
-    tty: true
-    volumes:
-      - model-cache:/webui/data
-
-volumes:
-  model-cache:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
-source $INSTALLDIR/venv/bin/activate
+# source $INSTALLDIR/venv/bin/activate
 
 # Ensure that --data-dir is set
 if [ -z $DATA_DIR ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
-# source $INSTALLDIR/venv/bin/activate
 
 # Ensure that --data-dir is set
 if [ -z $DATA_DIR ]; then
@@ -11,7 +10,7 @@ fi
 # Ensure that potentially bind-mounted directories are owned by the user that runs the service
 chown -R $RUN_UID:$RUN_UID $DATA_DIR
 # Create directory for temporary files and assign it to the user that runs the service
-mkdir /tmp/gradio
+mkdir -p /tmp/gradio
 chown -R $RUN_UID:$RUN_UID /tmp/gradio
 
 # Run service as specified (non-root) user


### PR DESCRIPTION
## Description

This is a minimalist approach to dockerizing this. It uses the sdnext installer during build by launching with the `--test` argument.

## Notes

This image is still 13gb uncompressed, but under 7 compressed, with or without extensions
![image](https://github.com/SaladTechnologies/sdnext/assets/6685047/7809fe0f-a136-4d3c-9acc-35b883dfbf00)

## Environment and Testing

WSL2 \ Ubuntu22 

```shell
docker compose up --build
```
